### PR TITLE
Added logic to validate Date Started should be earlier than date end …

### DIFF
--- a/src/main/java/com/karankumar/bookproject/ui/shelf/BookForm.java
+++ b/src/main/java/com/karankumar/bookproject/ui/shelf/BookForm.java
@@ -38,6 +38,7 @@ import com.vaadin.flow.data.binder.BeanValidationBinder;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.shared.Registration;
 
+import java.time.LocalDate;
 import java.util.List;
 
 /**
@@ -119,8 +120,13 @@ public class BookForm extends FormLayout {
 //                .bind(Book::getShelves, Book::setShelves);
         binder.forField(dateStartedReading)
                 .bind(Book::getDateStartedReading, Book::setDateStartedReading);
-        binder.forField(dateFinishedReading)
-                .bind(Book::getDateFinishedReading, Book::setDateFinishedReading);
+        Binder.Binding<Book, LocalDate> bindingEndDate = binder.forField(dateFinishedReading)
+                .withValidator(endDate -> !(endDate != null && dateStartedReading.getValue() != null && endDate
+                                .isBefore(dateStartedReading.getValue())),
+                        "Date Finished cannot earlier than Date Started")
+                .bind(Book::getDateStartedReading, Book::setDateStartedReading);
+        dateStartedReading.addValueChangeListener(
+                event -> bindingEndDate.validate());
         binder.forField(pageCount)
                 .bind(Book::getNumberOfPages, Book::setNumberOfPages);
         binder.forField(bookGenre)

--- a/src/main/java/com/karankumar/bookproject/ui/shelf/BookForm.java
+++ b/src/main/java/com/karankumar/bookproject/ui/shelf/BookForm.java
@@ -123,7 +123,7 @@ public class BookForm extends FormLayout {
         Binder.Binding<Book, LocalDate> bindingEndDate = binder.forField(dateFinishedReading)
                 .withValidator(endDate -> !(endDate != null && dateStartedReading.getValue() != null && endDate
                                 .isBefore(dateStartedReading.getValue())),
-                        "Date Finished cannot earlier than Date Started")
+                        "Date finished cannot be earlier than the date started")
                 .bind(Book::getDateStartedReading, Book::setDateStartedReading);
         dateStartedReading.addValueChangeListener(
                 event -> bindingEndDate.validate());


### PR DESCRIPTION
Added logic to validate Date Started should be earlier than date end if both Start and end date is not null

## Summary of change

Added logic to validate Date Started should be earlier than date end if both Start and end date is not null.
If end date is earlier then the logic will validate and will display the error message

## Additional context


![image](https://user-images.githubusercontent.com/36883385/83336553-148f7800-a2d2-11ea-96b3-c9656568d14b.png)
## Related issue

https://github.com/knjk04/book-project/issues/6
