### PR TITLE
remove @DirtiesContext

### DIFF
--- a/src/test/java/com/karankumar/bookproject/ui/BookFormTests.java
+++ b/src/test/java/com/karankumar/bookproject/ui/BookFormTests.java
@@ -41,14 +41,12 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 @WebAppConfiguration
-@DirtiesContext
 public class BookFormTests {
 
     private static final String firstName = "Nick";

--- a/src/test/java/com/karankumar/bookproject/ui/shelf/BooksInShelfViewTests.java
+++ b/src/test/java/com/karankumar/bookproject/ui/shelf/BooksInShelfViewTests.java
@@ -55,7 +55,6 @@ import org.springframework.test.context.web.WebAppConfiguration;
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 @WebAppConfiguration
-@DirtiesContext
 public class BooksInShelfViewTests {
 
     private static Routes routes;

--- a/src/test/java/com/karankumar/bookproject/ui/shelf/BooksInShelfViewTests.java
+++ b/src/test/java/com/karankumar/bookproject/ui/shelf/BooksInShelfViewTests.java
@@ -48,7 +48,6 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
-import org.springframework.test.annotation.Dirtiesontext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 

--- a/src/test/java/com/karankumar/bookproject/ui/shelf/BooksInShelfViewTests.java
+++ b/src/test/java/com/karankumar/bookproject/ui/shelf/BooksInShelfViewTests.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
-import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.Dirtiesontext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 


### PR DESCRIPTION
## Summary of change

DirtiesContext in BookFormTests drops all the tables and they are not recreated for the PredefinedShelfTests

## Related issue

Fixes #88 