### PR TITLE
Add global CSS file and fix log out link

### DIFF
--- a/frontend/styles/shared-styles.css
+++ b/frontend/styles/shared-styles.css
@@ -1,0 +1,5 @@
+.logout {
+  white-space: nowrap;
+  margin-right: 1em;
+  margin-left: -1em;
+}

--- a/frontend/styles/shared-styles.css
+++ b/frontend/styles/shared-styles.css
@@ -1,5 +1,5 @@
 .logout {
-  white-space: nowrap;
-  margin-right: 1em;
-  margin-left: -1em;
+    white-space: nowrap;
+    margin-right: 1em;
+    margin-left: -1em;
 }

--- a/src/main/java/com/karankumar/bookproject/ui/MainView.java
+++ b/src/main/java/com/karankumar/bookproject/ui/MainView.java
@@ -21,6 +21,7 @@ import com.karankumar.bookproject.ui.shelf.BooksInShelfView;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.applayout.AppLayout;
+import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.html.Anchor;
 import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.orderedlayout.FlexComponent;
@@ -34,6 +35,7 @@ import com.vaadin.flow.router.RouterLink;
 /**
  * Vaadin view that defines the app navigation bar
  */
+@CssImport("./styles/shared-styles.css")
 public class MainView extends AppLayout {
     public MainView() {
         Tabs tabs = new Tabs();
@@ -43,6 +45,7 @@ public class MainView extends AppLayout {
         tabs.add(myBooks, readingChallenge, settings);
 
         Anchor logout = new Anchor("/logout", "Log out");
+        logout.addClassName("logout");
 
         HorizontalLayout h = new HorizontalLayout();
 


### PR DESCRIPTION
## Summary of change

I created a global CSS file, added a class name for the logout anchor in MainView.java, imported the CSS file, and modified the log out link so it displays on one line. I added a small margin to give the log out link some space so that it wasn't so close to the right edge of the page.

## Additional context

**Google Chrome: Version 84.0.4147.89 (Official Build) (64-bit)**

![Chrome](https://user-images.githubusercontent.com/39063497/87665763-7185a700-c735-11ea-847f-03e4eeed07bc.PNG)

**Mozilla Firefox: 78.0.2 (64-bit)**

![Firefox](https://user-images.githubusercontent.com/39063497/87665818-83ffe080-c735-11ea-80ef-583f24fe8a53.PNG)

## Related issue

https://github.com/knjk04/book-project/issues/62
