### PR TITLE
Implement exception handling for unsupported shelf

### DIFF
--- a/src/main/java/com/karankumar/bookproject/ui/shelf/BooksInShelfView.java
+++ b/src/main/java/com/karankumar/bookproject/ui/shelf/BooksInShelfView.java
@@ -34,6 +34,7 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteAlias;
 import lombok.extern.java.Log;
 
+import javax.transaction.NotSupportedException;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.util.Comparator;
@@ -109,31 +110,38 @@ public class BooksInShelfView extends VerticalLayout {
                     } else {
                         chosenShelf = event.getValue();
                         updateGrid();
-                        showOrHideGridColumns(chosenShelf);
+                        try {
+                            showOrHideGridColumns(chosenShelf);
+                        } catch (NotSupportedException e) {
+                            e.printStackTrace();
+                        }
                     }
                 });
     }
 
-    void showOrHideGridColumns(PredefinedShelf.ShelfName shelfName) {
+    /**
+     * @throws NotSupportedException if a shelf is not supported.
+     */
+    void showOrHideGridColumns(PredefinedShelf.ShelfName shelfName) throws NotSupportedException {
         switch (shelfName) {
             case TO_READ:
                 toggleColumnVisibility(RATING_KEY, false);
                 toggleColumnVisibility(DATE_STARTED_KEY, false);
                 toggleColumnVisibility(DATE_FINISHED_KEY, false);
-                break;
+                return;
             case READING:
             case DID_NOT_FINISH:
                 toggleColumnVisibility(RATING_KEY, false);
                 toggleColumnVisibility(DATE_STARTED_KEY, true);
                 toggleColumnVisibility(DATE_FINISHED_KEY, false);
-                break;
+                return;
             case READ:
                 toggleColumnVisibility(RATING_KEY, true);
                 toggleColumnVisibility(DATE_STARTED_KEY, true);
                 toggleColumnVisibility(DATE_FINISHED_KEY, true);
-                break;
-            default:
+                return;
         }
+        throw new NotSupportedException("Shelf " + shelfName + " has not been added as a case in switch statement.");
     }
 
     private void toggleColumnVisibility(String columnKey, boolean showColumn) {

--- a/src/test/java/com/karankumar/bookproject/ui/shelf/BooksInShelfViewTests.java
+++ b/src/test/java/com/karankumar/bookproject/ui/shelf/BooksInShelfViewTests.java
@@ -65,26 +65,26 @@ public class BooksInShelfViewTests {
     private ApplicationContext ctx;
 
     private final ArrayList<String> expectedToReadColumns = new ArrayList<>(Arrays.asList(
-            TITLE_KEY,
-            AUTHOR_KEY,
-            GENRE_KEY,
-            PAGES_KEY
+        TITLE_KEY,
+        AUTHOR_KEY,
+        GENRE_KEY,
+        PAGES_KEY
     ));
     private final ArrayList<String> expectedReadingColumns = new ArrayList<>(Arrays.asList(
-            TITLE_KEY,
-            AUTHOR_KEY,
-            GENRE_KEY,
-            DATE_STARTED_KEY,
-            PAGES_KEY
+        TITLE_KEY,
+        AUTHOR_KEY,
+        GENRE_KEY,
+        DATE_STARTED_KEY,
+        PAGES_KEY
     ));
     private final ArrayList<String> expectedReadColumns = new ArrayList<>(Arrays.asList(
-            TITLE_KEY,
-            AUTHOR_KEY,
-            GENRE_KEY,
-            DATE_STARTED_KEY,
-            DATE_FINISHED_KEY,
-            RATING_KEY,
-            PAGES_KEY
+        TITLE_KEY,
+        AUTHOR_KEY,
+        GENRE_KEY,
+        DATE_STARTED_KEY,
+        DATE_FINISHED_KEY,
+        RATING_KEY,
+        PAGES_KEY
     ));
     private BooksInShelfView shelfView;
 

--- a/src/test/java/com/karankumar/bookproject/ui/shelf/BooksInShelfViewTests.java
+++ b/src/test/java/com/karankumar/bookproject/ui/shelf/BooksInShelfViewTests.java
@@ -23,7 +23,6 @@ import static com.karankumar.bookproject.ui.shelf.BooksInShelfView.PAGES_KEY;
 import static com.karankumar.bookproject.ui.shelf.BooksInShelfView.RATING_KEY;
 import static com.karankumar.bookproject.ui.shelf.BooksInShelfView.TITLE_KEY;
 
-
 import com.github.mvysny.kaributesting.v10.MockVaadin;
 import com.github.mvysny.kaributesting.v10.Routes;
 import com.karankumar.bookproject.backend.entity.Book;
@@ -34,9 +33,11 @@ import com.karankumar.bookproject.ui.MockSpringServlet;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.spring.SpringServlet;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
@@ -51,6 +52,8 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 
+import javax.transaction.NotSupportedException;
+
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 @WebAppConfiguration
@@ -62,26 +65,26 @@ public class BooksInShelfViewTests {
     private ApplicationContext ctx;
 
     private final ArrayList<String> expectedToReadColumns = new ArrayList<>(Arrays.asList(
-        TITLE_KEY,
-        AUTHOR_KEY,
-        GENRE_KEY,
-        PAGES_KEY
+            TITLE_KEY,
+            AUTHOR_KEY,
+            GENRE_KEY,
+            PAGES_KEY
     ));
     private final ArrayList<String> expectedReadingColumns = new ArrayList<>(Arrays.asList(
-        TITLE_KEY,
-        AUTHOR_KEY,
-        GENRE_KEY,
-        DATE_STARTED_KEY,
-        PAGES_KEY
+            TITLE_KEY,
+            AUTHOR_KEY,
+            GENRE_KEY,
+            DATE_STARTED_KEY,
+            PAGES_KEY
     ));
     private final ArrayList<String> expectedReadColumns = new ArrayList<>(Arrays.asList(
-        TITLE_KEY,
-        AUTHOR_KEY,
-        GENRE_KEY,
-        DATE_STARTED_KEY,
-        DATE_FINISHED_KEY,
-        RATING_KEY,
-        PAGES_KEY
+            TITLE_KEY,
+            AUTHOR_KEY,
+            GENRE_KEY,
+            DATE_STARTED_KEY,
+            DATE_FINISHED_KEY,
+            RATING_KEY,
+            PAGES_KEY
     ));
     private BooksInShelfView shelfView;
 
@@ -104,8 +107,12 @@ public class BooksInShelfViewTests {
     @EnumSource(PredefinedShelf.ShelfName.class)
     public void correctGridColumnsShow(PredefinedShelf.ShelfName shelfName) {
         System.out.println("Shelf: " + shelfName);
+        try {
+            shelfView.showOrHideGridColumns(shelfName);
+        } catch (NotSupportedException e) {
+            e.printStackTrace();
+        }
 
-        shelfView.showOrHideGridColumns(shelfName);
         List<Grid.Column<Book>> columns = shelfView.bookGrid.getColumns();
 
         ArrayList<String> expectedColumns = new ArrayList<>();


### PR DESCRIPTION
## Summary of change

I implemented exception handling for when a predefined shelf has been created but not added as a case in the switch statement and added a Javadoc comment for it. Per our discussion in Gitter, I decided to throw the exception outside of the switch statement. I also did a manual test where I created a shelf but did not add a case for it to see if the exception would be thrown and it indeed threw an exception and printed the stack trace.

## Related issue

https://github.com/knjk04/book-project/issues/165
