### PR TITLE
Disable save button on click to avoid duplicates on shelf 200

### DIFF
--- a/src/main/java/com/karankumar/bookproject/ui/book/BookForm.java
+++ b/src/main/java/com/karankumar/bookproject/ui/book/BookForm.java
@@ -243,6 +243,7 @@ public class BookForm extends VerticalLayout {
         saveButton.setText(LABEL_ADD_BOOK);
         saveButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
         saveButton.addClickListener(click -> validateOnSave());
+        saveButton.setDisableOnClick(true);
     }
 
     private void configureResetFormButton() {
@@ -266,7 +267,6 @@ public class BookForm extends VerticalLayout {
     private void validateOnSave() {
         if (binder.isValid()) {
             LOGGER.log(Level.INFO, "Valid binder");
-
             if (binder.getBean() == null) {
                 LOGGER.log(Level.SEVERE, "Binder book bean is null");
                 setBookBean();


### PR DESCRIPTION
## Summary of change

Changed the save button so that it disables itself after being clicked. It re-enables itself once the user fills in the required fields. This avoids the situation where the user can click-spam the button to create multiple books with the same form.

## Related issue
https://github.com/knjk04/book-project/issues/200
