### PR TITLE
add field for book review to frontend, toggle its visibility based on…

### DIFF
--- a/src/main/java/com/karankumar/bookproject/ui/book/BookForm.java
+++ b/src/main/java/com/karankumar/bookproject/ui/book/BookForm.java
@@ -46,6 +46,7 @@ import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.IntegerField;
 import com.vaadin.flow.component.textfield.NumberField;
+import com.vaadin.flow.component.textfield.TextArea;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.binder.BeanValidationBinder;
 import com.vaadin.flow.data.binder.Binder;
@@ -87,6 +88,7 @@ public class BookForm extends VerticalLayout {
     @VisibleForTesting final DatePicker dateStartedReading = new DatePicker();
     @VisibleForTesting final DatePicker dateFinishedReading = new DatePicker();
     @VisibleForTesting final NumberField rating = new NumberField();
+    @VisibleForTesting final TextArea bookReview = new TextArea();
     @VisibleForTesting final Button saveButton = new Button();
     @VisibleForTesting final Checkbox inSeriesCheckbox = new Checkbox();
     @VisibleForTesting final Button reset = new Button();
@@ -94,6 +96,7 @@ public class BookForm extends VerticalLayout {
     @VisibleForTesting FormLayout.FormItem dateStartedReadingFormItem;
     @VisibleForTesting FormLayout.FormItem dateFinishedReadingFormItem;
     @VisibleForTesting FormLayout.FormItem ratingFormItem;
+    @VisibleForTesting FormLayout.FormItem bookReviewFormItem;
     @VisibleForTesting FormLayout.FormItem seriesPositionFormItem;
     @VisibleForTesting FormLayout.FormItem pagesReadFormItem;
 
@@ -127,6 +130,7 @@ public class BookForm extends VerticalLayout {
         configureDateStartedFormField();
         configureDateFinishedFormField();
         configureRatingFormField();
+        configureBookReviewFormField();
         configureInSeriesFormField();
         HorizontalLayout buttons = configureFormButtons();
         HasSize[] components = {
@@ -142,6 +146,7 @@ public class BookForm extends VerticalLayout {
                 pagesRead,
                 numberOfPages,
                 rating,
+                bookReview
         };
         ComponentUtil.setComponentMinWidth(components);
         configureFormLayout(formLayout, buttons);
@@ -178,6 +183,7 @@ public class BookForm extends VerticalLayout {
         ratingFormItem = formLayout.addFormItem(rating, "Book rating");
         formLayout.addFormItem(inSeriesCheckbox, "Is in series?");
         seriesPositionFormItem = formLayout.addFormItem(seriesPosition, "Series number");
+        bookReviewFormItem = formLayout.addFormItem(bookReview, "Book review");
         formLayout.add(buttonLayout, 3);
         seriesPositionFormItem.setVisible(false);
     }
@@ -237,6 +243,8 @@ public class BookForm extends VerticalLayout {
         binder.forField(rating)
               .withConverter(new DoubleToRatingScaleConverter())
               .bind(Book::getRating, Book::setRating);
+        binder.forField(bookReview)
+              .bind(Book::getBookReview, Book::setBookReview);
     }
 
     /**
@@ -367,6 +375,7 @@ public class BookForm extends VerticalLayout {
                 new DoubleToRatingScaleConverter().convertToModel(rating.getValue(), null);
         result.ifOk((SerializableConsumer<RatingScale>) book::setRating);
 
+        book.setBookReview(bookReview.getValue());
         book.setPagesRead(pagesRead.getValue());
 
         if (seriesPosition.getValue() != null && seriesPosition.getValue() > 0) {
@@ -468,7 +477,7 @@ public class BookForm extends VerticalLayout {
             if (event.getValue() != null) {
                 try {
                     hideDates(predefinedShelfField.getValue());
-                    showOrHideRating(predefinedShelfField.getValue());
+                    showOrHideRatingAndBookReview(predefinedShelfField.getValue());
                     showOrHidePagesRead(predefinedShelfField.getValue());
                 } catch (NotSupportedException e) {
                     e.printStackTrace();
@@ -545,21 +554,23 @@ public class BookForm extends VerticalLayout {
     }
 
     /**
-     * Toggles showing the rating depending on which shelf this new book is going into
+     * Toggles showing the rating and the bookReview depending on which shelf this new book is going into
      *
      * @param name the name of the shelf that was selected in this book form
      * @throws NotSupportedException if the shelf name parameter does not match the name of
      *                               a @see PredefinedShelf
      */
-    private void showOrHideRating(PredefinedShelf.ShelfName name) throws NotSupportedException {
+    private void showOrHideRatingAndBookReview(PredefinedShelf.ShelfName name) throws NotSupportedException {
         switch (name) {
             case TO_READ:
             case READING:
             case DID_NOT_FINISH:
                 ratingFormItem.setVisible(false);
+                bookReviewFormItem.setVisible(false);
                 break;
             case READ:
                 ratingFormItem.setVisible(true);
+                bookReviewFormItem.setVisible(true);
                 break;
             default:
                 throw new NotSupportedException("Shelf " + name + " not yet supported");
@@ -573,6 +584,11 @@ public class BookForm extends VerticalLayout {
         rating.setMax(10);
         rating.setStep(0.5f);
         rating.setClearButtonVisible(true);
+    }
+
+    private void configureBookReviewFormField() {
+        bookReview.setPlaceholder("Enter your review for the book");
+        bookReview.setClearButtonVisible(true);
     }
 
     private void configureDateStartedFormField() {
@@ -614,6 +630,7 @@ public class BookForm extends VerticalLayout {
                 dateStartedReading,
                 dateFinishedReading,
                 rating,
+                bookReview
         };
         resetSaveButtonText();
         ComponentUtil.clearComponentFields(components);

--- a/src/test/java/com/karankumar/bookproject/ui/book/BookFormTest.java
+++ b/src/test/java/com/karankumar/bookproject/ui/book/BookFormTest.java
@@ -60,6 +60,7 @@ public class BookFormTest {
     private static final LocalDate dateStarted = LocalDate.now().minusDays(4);
     private static final LocalDate dateFinished = LocalDate.now();
     private static final RatingScale ratingVal = RatingScale.NINE;
+    private static final String bookReview = "Very good. Would read again.";
     private static DoubleToRatingScaleConverter converter = new DoubleToRatingScaleConverter();
     private static final int SERIES_POSITION = 10;
     private static int pagesRead;
@@ -125,6 +126,7 @@ public class BookFormTest {
         book.setDateStartedReading(dateStarted);
         book.setDateFinishedReading(dateFinished);
         book.setRating(ratingVal);
+        book.setBookReview(bookReview);
         if (isInSeries) {
             book.setSeriesPosition(seriesPosition);
         }
@@ -153,6 +155,7 @@ public class BookFormTest {
         Assertions.assertEquals(dateFinished, bookForm.dateFinishedReading.getValue());
         double rating = converter.convertToPresentation(ratingVal, null);
         Assertions.assertEquals(rating, bookForm.rating.getValue());
+        Assertions.assertEquals(bookReview, bookForm.bookReview.getValue());
         Assertions.assertEquals(seriesPosition, bookForm.seriesPosition.getValue());
     }
 
@@ -195,6 +198,7 @@ public class BookFormTest {
         Assertions.assertEquals(dateStarted, savedOrDeletedBook.getDateStartedReading());
         Assertions.assertEquals(dateFinished, savedOrDeletedBook.getDateFinishedReading());
         Assertions.assertEquals(ratingVal, savedOrDeletedBook.getRating());
+        Assertions.assertEquals(bookReview, savedOrDeletedBook.getBookReview());
         Assertions.assertEquals(seriesPosition, savedOrDeletedBook.getSeriesPosition());
     }
 
@@ -209,6 +213,7 @@ public class BookFormTest {
         bookForm.dateStartedReading.setValue(dateStarted);
         bookForm.dateFinishedReading.setValue(dateFinished);
         bookForm.rating.setValue(converter.convertToPresentation(ratingVal, null));
+        bookForm.bookReview.setValue(bookReview);
     }
 
     /**
@@ -235,6 +240,7 @@ public class BookFormTest {
         Assertions.assertTrue(bookForm.dateStartedReading.isEmpty());
         Assertions.assertTrue(bookForm.dateFinishedReading.isEmpty());
         Assertions.assertTrue(bookForm.rating.isEmpty());
+        Assertions.assertTrue(bookForm.bookReview.isEmpty());
     }
 
     private void assumeAllFormFieldsArePopulated() {
@@ -247,6 +253,8 @@ public class BookFormTest {
         Assumptions.assumeFalse(bookForm.numberOfPages.isEmpty());
         Assumptions.assumeFalse(bookForm.dateStartedReading.isEmpty());
         Assumptions.assumeFalse(bookForm.dateFinishedReading.isEmpty());
+        Assumptions.assumeFalse(bookForm.rating.isEmpty());
+        Assumptions.assumeFalse(bookForm.bookReview.isEmpty());
     }
 
     @Test
@@ -255,6 +263,7 @@ public class BookFormTest {
         Assertions.assertFalse(bookForm.dateStartedReadingFormItem.isVisible());
         Assertions.assertFalse(bookForm.dateFinishedReadingFormItem.isVisible());
         Assertions.assertFalse(bookForm.ratingFormItem.isVisible());
+        Assertions.assertFalse(bookForm.bookReviewFormItem.isVisible());
         Assertions.assertFalse(bookForm.pagesReadFormItem.isVisible());
     }
 
@@ -264,6 +273,7 @@ public class BookFormTest {
         Assertions.assertTrue(bookForm.dateStartedReadingFormItem.isVisible());
         Assertions.assertFalse(bookForm.dateFinishedReadingFormItem.isVisible());
         Assertions.assertFalse(bookForm.ratingFormItem.isVisible());
+        Assertions.assertFalse(bookForm.bookReviewFormItem.isVisible());
         Assertions.assertFalse(bookForm.pagesReadFormItem.isVisible());
     }
 
@@ -273,6 +283,7 @@ public class BookFormTest {
         Assertions.assertTrue(bookForm.dateStartedReadingFormItem.isVisible());
         Assertions.assertTrue(bookForm.dateFinishedReadingFormItem.isVisible());
         Assertions.assertTrue(bookForm.ratingFormItem.isVisible());
+        Assertions.assertTrue(bookForm.bookReviewFormItem.isVisible());
         Assertions.assertFalse(bookForm.pagesReadFormItem.isVisible());
     }
 
@@ -282,6 +293,7 @@ public class BookFormTest {
         Assertions.assertTrue(bookForm.dateStartedReadingFormItem.isVisible());
         Assertions.assertFalse(bookForm.dateFinishedReadingFormItem.isVisible());
         Assertions.assertFalse(bookForm.ratingFormItem.isVisible());
+        Assertions.assertFalse(bookForm.bookReviewFormItem.isVisible());
         Assertions.assertTrue(bookForm.pagesReadFormItem.isVisible());
     }
 


### PR DESCRIPTION
## Summary of change

This Pull request adds a text area for the bookReview to the frontend.

## Additional context
Layout in full width book form:
![image](https://user-images.githubusercontent.com/58065733/91635656-76a76880-e9fa-11ea-9aca-ce5d9f9c9859.png)
Layout with single column:
![image](https://user-images.githubusercontent.com/58065733/91635644-5f687b00-e9fa-11ea-8747-72d85c7caac0.png)

## Related issue

#171 