### PR TITLE
Fix overlapping form labels

### DIFF
--- a/frontend/styles/book-form-styles.css
+++ b/frontend/styles/book-form-styles.css
@@ -1,0 +1,18 @@
+@media screen and (max-width: 37em) {
+    .formInputField {
+        width: 100%;
+    }
+}
+
+@media screen and (min-width: 37em) {
+    .formInputField {
+        width: 23em;
+    }
+}
+
+@media screen and (max-width: 37em) {
+    .formButtonLayout {
+        flex-wrap: wrap;
+        flex-direction: column;
+    }
+}

--- a/frontend/styles/vaadin-dialog-overlay-styles.css
+++ b/frontend/styles/vaadin-dialog-overlay-styles.css
@@ -1,3 +1,17 @@
-[part="overlay"]{
-    width:60%;
+@media screen and (max-width: 37em) {
+    [part="overlay"] {
+        width:95%;
+    }
+}
+
+@media screen and (min-width: 37em) {
+    [part="overlay"] {
+        width:35em;
+    }
+}
+
+@media screen and (min-width: 70em) {
+    [part="overlay"] {
+        width:68em;
+    }
 }

--- a/src/main/java/com/karankumar/bookproject/ui/book/BookForm.java
+++ b/src/main/java/com/karankumar/bookproject/ui/book/BookForm.java
@@ -68,6 +68,9 @@ import java.util.logging.Level;
         value = "./styles/vaadin-dialog-overlay-styles.css",
         themeFor = "vaadin-dialog-overlay"
 )
+@CssImport(
+        value = "./styles/book-form-styles.css"
+)
 @Log
 public class BookForm extends VerticalLayout {
     private static final String ENTER_DATE = "Enter a date";
@@ -143,7 +146,7 @@ public class BookForm extends VerticalLayout {
                 numberOfPages,
                 rating,
         };
-        ComponentUtil.setComponentMinWidth(components);
+        ComponentUtil.setComponentClassName(components);
         configureFormLayout(formLayout, buttons);
 
         add(dialog);
@@ -164,7 +167,12 @@ public class BookForm extends VerticalLayout {
      * @param buttonLayout a layout consisting of buttons
      */
     private void configureFormLayout(FormLayout formLayout, HorizontalLayout buttonLayout) {
-        formLayout.setResponsiveSteps();
+        formLayout.setResponsiveSteps(
+                new FormLayout.ResponsiveStep("0", 1, FormLayout.ResponsiveStep.LabelsPosition.TOP),
+                new FormLayout.ResponsiveStep("31em", 1),
+                new FormLayout.ResponsiveStep("62em", 2)
+        );
+
         formLayout.addFormItem(bookTitle, "Book title *");
         formLayout.addFormItem(predefinedShelfField, "Book shelf *");
         formLayout.addFormItem(customShelfField, "Secondary shelf");
@@ -249,7 +257,9 @@ public class BookForm extends VerticalLayout {
 
         binder.addStatusChangeListener(event -> saveButton.setEnabled(binder.isValid()));
 
-        return new HorizontalLayout(saveButton, reset, delete);
+        HorizontalLayout buttonLayout = new HorizontalLayout(saveButton, reset, delete);
+        buttonLayout.addClassName("formButtonLayout");
+        return buttonLayout;
     }
 
     private void configureSaveFormButton() {

--- a/src/main/java/com/karankumar/bookproject/ui/components/utils/ComponentUtil.java
+++ b/src/main/java/com/karankumar/bookproject/ui/components/utils/ComponentUtil.java
@@ -23,9 +23,9 @@ import com.vaadin.flow.component.HasValue;
 public class ComponentUtil {
     private ComponentUtil() {}
 
-    public static void setComponentMinWidth(HasSize[] components) {
+    public static void setComponentClassName(HasSize[] components) {
         for (HasSize h : components) {
-            h.setMinWidth("23em");
+            h.getElement().getClassList().add("formInputField");
         }
     }
 


### PR DESCRIPTION
## Summary of change

This PR solves the problem, that the different input fields in the form to add a book, did overlap when the screen was not wide enough.

## Additional context
width >= 70em:
![image](https://user-images.githubusercontent.com/58065733/91665900-2a8f1d80-eaf9-11ea-8f7c-f1e4599f1128.png)

width >= 37em:
![image](https://user-images.githubusercontent.com/58065733/91665917-3975d000-eaf9-11ea-9599-d7e7b979911a.png)

width < 37em:
![image](https://user-images.githubusercontent.com/58065733/91665924-514d5400-eaf9-11ea-96d2-694ccf9976c8.png)

## Related issue
 
#57 