### PR TITLE
Reset fields when book is moved between shelves

### DIFF
--- a/src/main/java/com/karankumar/bookproject/ui/book/BookForm.java
+++ b/src/main/java/com/karankumar/bookproject/ui/book/BookForm.java
@@ -102,6 +102,15 @@ public class BookForm extends VerticalLayout {
 
     @VisibleForTesting HasValue[] fieldsToReset;
 
+    @VisibleForTesting final HasValue[] fieldsToResetForToRead
+            = new HasValue[]{pagesRead, dateStartedReading, dateFinishedReading, rating, bookReview};
+    @VisibleForTesting final HasValue[] fieldsToResetForReading
+            = new HasValue[]{pagesRead, dateFinishedReading, rating, bookReview};
+    @VisibleForTesting final HasValue[] fieldsToResetForRead
+            = new HasValue[]{pagesRead};
+    @VisibleForTesting final HasValue[] fieldsToResetForDidNotFinish
+            = new HasValue[]{dateFinishedReading, rating, bookReview};
+
     @VisibleForTesting Button delete = new Button();
     @VisibleForTesting Binder<Book> binder = new BeanValidationBinder<>(Book.class);
 
@@ -590,19 +599,20 @@ public class BookForm extends VerticalLayout {
      *                               a @see PredefinedShelf
      */
     private void setFieldsToReset(PredefinedShelf.ShelfName shelfName) throws NotSupportedException {
+        fieldsToReset = getFieldsToReset(shelfName);
+    }
+
+    @VisibleForTesting
+    HasValue[] getFieldsToReset(PredefinedShelf.ShelfName shelfName) throws NotSupportedException {
         switch (shelfName) {
             case TO_READ:
-                fieldsToReset = new HasValue[]{pagesRead, dateStartedReading, dateFinishedReading, rating, bookReview};
-                break;
+                return fieldsToResetForToRead;
             case READING:
-                fieldsToReset = new HasValue[]{pagesRead, dateFinishedReading, rating, bookReview};
-                break;
+                return fieldsToResetForReading;
             case READ:
-                fieldsToReset = new HasValue[]{pagesRead};
-                break;
+                return fieldsToResetForRead;
             case DID_NOT_FINISH:
-                fieldsToReset = new HasValue[]{dateFinishedReading, rating, bookReview};
-                break;
+                return fieldsToResetForDidNotFinish;
             default:
                 throw new NotSupportedException("Shelf " + shelfName + " not yet supported");
         }

--- a/src/main/java/com/karankumar/bookproject/ui/book/BookForm.java
+++ b/src/main/java/com/karankumar/bookproject/ui/book/BookForm.java
@@ -100,6 +100,8 @@ public class BookForm extends VerticalLayout {
     @VisibleForTesting FormLayout.FormItem seriesPositionFormItem;
     @VisibleForTesting FormLayout.FormItem pagesReadFormItem;
 
+    @VisibleForTesting HasValue[] fieldsToReset;
+
     @VisibleForTesting Button delete = new Button();
     @VisibleForTesting Binder<Book> binder = new BeanValidationBinder<>(Book.class);
 
@@ -291,6 +293,7 @@ public class BookForm extends VerticalLayout {
             } else {
                 LOGGER.log(Level.INFO, "Binder.getBean() is not null");
                 moveBookToDifferentShelf();
+                ComponentUtil.clearComponentFields(fieldsToReset);
                 fireEvent(new SaveEvent(this, binder.getBean()));
                 closeForm();
             }
@@ -307,6 +310,7 @@ public class BookForm extends VerticalLayout {
 
         if (binder.getBean() != null) {
             LOGGER.log(Level.INFO, "Written bean. Not Null.");
+            ComponentUtil.clearComponentFields(fieldsToReset);
             fireEvent(new SaveEvent(this, binder.getBean()));
             showSavedConfirmation();
         } else {
@@ -479,6 +483,7 @@ public class BookForm extends VerticalLayout {
                     hideDates(predefinedShelfField.getValue());
                     showOrHideRatingAndBookReview(predefinedShelfField.getValue());
                     showOrHidePagesRead(predefinedShelfField.getValue());
+                    setFieldsToReset(predefinedShelfField.getValue());
                 } catch (NotSupportedException e) {
                     e.printStackTrace();
                 }
@@ -574,6 +579,32 @@ public class BookForm extends VerticalLayout {
                 break;
             default:
                 throw new NotSupportedException("Shelf " + name + " not yet supported");
+        }
+    }
+
+    /**
+     * Populates the fieldsToReset array with state-specific fields depending on which shelf the book is going into
+     *
+     * @param shelfName the name of the shelf that was selected in this book form
+     * @throws NotSupportedException if the shelf name parameter does not match the name of
+     *                               a @see PredefinedShelf
+     */
+    private void setFieldsToReset(PredefinedShelf.ShelfName shelfName) throws NotSupportedException {
+        switch (shelfName) {
+            case TO_READ:
+                fieldsToReset = new HasValue[]{pagesRead, dateStartedReading, dateFinishedReading, rating, bookReview};
+                break;
+            case READING:
+                fieldsToReset = new HasValue[]{pagesRead, dateFinishedReading, rating, bookReview};
+                break;
+            case READ:
+                fieldsToReset = new HasValue[]{pagesRead};
+                break;
+            case DID_NOT_FINISH:
+                fieldsToReset = new HasValue[]{dateFinishedReading, rating, bookReview};
+                break;
+            default:
+                throw new NotSupportedException("Shelf " + shelfName + " not yet supported");
         }
     }
 

--- a/src/test/java/com/karankumar/bookproject/ui/book/BookFormTest.java
+++ b/src/test/java/com/karankumar/bookproject/ui/book/BookFormTest.java
@@ -379,7 +379,7 @@ public class BookFormTest {
         // then
         Assertions.assertEquals(fieldsThatShouldBeReset.length, bookForm.fieldsToReset.length);
         Assertions.assertTrue(List.of(bookForm.fieldsToReset)
-                              .containsAll(List.of(fieldsThatShouldBeReset)));
+                                  .containsAll(List.of(fieldsThatShouldBeReset)));
     }
 
     @Test

--- a/src/test/java/com/karankumar/bookproject/ui/book/BookFormTest.java
+++ b/src/test/java/com/karankumar/bookproject/ui/book/BookFormTest.java
@@ -49,8 +49,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.web.WebAppConfiguration;
 
+import javax.transaction.NotSupportedException;
 import java.time.LocalDate;
- import java.util.List;
+import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
@@ -355,66 +356,25 @@ public class BookFormTest {
         Assertions.assertTrue(bookForm.pagesReadFormItem.isVisible());
     }
 
-    @Test
-    void fieldsToResetIsCorrectlyPopulatedForToReadShelf() {
-        // given
-        HasValue[] fieldsThatShouldBeReset = new HasValue[]{bookForm.dateStartedReading,
-                bookForm.dateFinishedReading, bookForm.pagesRead, bookForm.rating, bookForm.bookReview};
-        populateBookForm(READ, false);
-        bookForm.pagesRead.setValue(pagesRead);
-
-        // when
-        bookForm.predefinedShelfField.setValue(TO_READ);
-
-        // then
-        Assertions.assertEquals(fieldsThatShouldBeReset.length, bookForm.fieldsToReset.length);
-        Assertions.assertTrue(List.of(bookForm.fieldsToReset)
-                              .containsAll(List.of(fieldsThatShouldBeReset)));
+    private static Stream<Arguments> shelfNames() {
+        return Stream.of(
+                Arguments.of(TO_READ),
+                Arguments.of(READING),
+                Arguments.of(READ),
+                Arguments.of(DID_NOT_FINISH)
+        );
     }
 
-    @Test
-    void fieldsToResetIsCorrectlyPopulatedForReadingShelf() {
+    @ParameterizedTest
+    @MethodSource("shelfNames")
+    void fieldsToResetIsCorrectlyPopulated(PredefinedShelf.ShelfName newShelf) throws NotSupportedException {
         // given
-        HasValue[] fieldsThatShouldBeReset = new HasValue[]{bookForm.dateFinishedReading,
-                bookForm.pagesRead, bookForm.rating, bookForm.bookReview};
+        HasValue[] fieldsThatShouldBeReset = bookForm.getFieldsToReset(newShelf);
         populateBookForm(READ, false);
         bookForm.pagesRead.setValue(pagesRead);
 
         // when
-        bookForm.predefinedShelfField.setValue(READING);
-
-        // then
-        Assertions.assertEquals(fieldsThatShouldBeReset.length, bookForm.fieldsToReset.length);
-        Assertions.assertTrue(List.of(bookForm.fieldsToReset)
-                              .containsAll(List.of(fieldsThatShouldBeReset)));
-    }
-
-    @Test
-    void fieldsToResetIsCorrectlyPopulatedForReadShelf() {
-        // given
-        HasValue[] fieldsThatShouldBeReset = new HasValue[]{bookForm.pagesRead};
-        populateBookForm(READ, false);
-        bookForm.pagesRead.setValue(pagesRead);
-
-        // when
-        bookForm.predefinedShelfField.setValue(READ);
-
-        // then
-        Assertions.assertEquals(fieldsThatShouldBeReset.length, bookForm.fieldsToReset.length);
-        Assertions.assertTrue(List.of(bookForm.fieldsToReset)
-                              .containsAll(List.of(fieldsThatShouldBeReset)));
-    }
-
-    @Test
-    void fieldsToResetIsCorrectlyPopulatedForDidNotFinishShelf() {
-        // given
-        HasValue[] fieldsThatShouldBeReset = new HasValue[]{bookForm.dateFinishedReading,
-                bookForm.rating, bookForm.bookReview};
-        populateBookForm(READ, false);
-        bookForm.pagesRead.setValue(pagesRead);
-
-        // when
-        bookForm.predefinedShelfField.setValue(DID_NOT_FINISH);
+        bookForm.predefinedShelfField.setValue(newShelf);
 
         // then
         Assertions.assertEquals(fieldsThatShouldBeReset.length, bookForm.fieldsToReset.length);

--- a/src/test/java/com/karankumar/bookproject/ui/book/BookFormTest.java
+++ b/src/test/java/com/karankumar/bookproject/ui/book/BookFormTest.java
@@ -31,6 +31,7 @@ import com.karankumar.bookproject.backend.service.CustomShelfService;
 import com.karankumar.bookproject.backend.service.PredefinedShelfService;
 import com.karankumar.bookproject.backend.utils.PredefinedShelfUtils;
 import com.karankumar.bookproject.ui.MockSpringServlet;
+import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.data.binder.BinderValidationStatus;
 import com.vaadin.flow.spring.SpringServlet;
@@ -49,6 +50,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import java.time.LocalDate;
+ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
@@ -354,6 +356,73 @@ public class BookFormTest {
     }
 
     @Test
+    void fieldsToResetIsCorrectlyPopulatedForToReadShelf() {
+        // given
+        HasValue[] fieldsThatShouldBeReset = new HasValue[]{bookForm.dateStartedReading,
+                bookForm.dateFinishedReading, bookForm.pagesRead, bookForm.rating, bookForm.bookReview};
+        populateBookForm(READ, false);
+        bookForm.pagesRead.setValue(pagesRead);
+
+        // when
+        bookForm.predefinedShelfField.setValue(TO_READ);
+
+        // then
+        Assertions.assertEquals(fieldsThatShouldBeReset.length, bookForm.fieldsToReset.length);
+        Assertions.assertTrue(List.of(bookForm.fieldsToReset)
+                              .containsAll(List.of(fieldsThatShouldBeReset)));
+    }
+
+    @Test
+    void fieldsToResetIsCorrectlyPopulatedForReadingShelf() {
+        // given
+        HasValue[] fieldsThatShouldBeReset = new HasValue[]{bookForm.dateFinishedReading,
+                bookForm.pagesRead, bookForm.rating, bookForm.bookReview};
+        populateBookForm(READ, false);
+        bookForm.pagesRead.setValue(pagesRead);
+
+        // when
+        bookForm.predefinedShelfField.setValue(READING);
+
+        // then
+        Assertions.assertEquals(fieldsThatShouldBeReset.length, bookForm.fieldsToReset.length);
+        Assertions.assertTrue(List.of(bookForm.fieldsToReset)
+                              .containsAll(List.of(fieldsThatShouldBeReset)));
+    }
+
+    @Test
+    void fieldsToResetIsCorrectlyPopulatedForReadShelf() {
+        // given
+        HasValue[] fieldsThatShouldBeReset = new HasValue[]{bookForm.pagesRead};
+        populateBookForm(READ, false);
+        bookForm.pagesRead.setValue(pagesRead);
+
+        // when
+        bookForm.predefinedShelfField.setValue(READ);
+
+        // then
+        Assertions.assertEquals(fieldsThatShouldBeReset.length, bookForm.fieldsToReset.length);
+        Assertions.assertTrue(List.of(bookForm.fieldsToReset)
+                              .containsAll(List.of(fieldsThatShouldBeReset)));
+    }
+
+    @Test
+    void fieldsToResetIsCorrectlyPopulatedForDidNotFinishShelf() {
+        // given
+        HasValue[] fieldsThatShouldBeReset = new HasValue[]{bookForm.dateFinishedReading,
+                bookForm.rating, bookForm.bookReview};
+        populateBookForm(READ, false);
+        bookForm.pagesRead.setValue(pagesRead);
+
+        // when
+        bookForm.predefinedShelfField.setValue(DID_NOT_FINISH);
+
+        // then
+        Assertions.assertEquals(fieldsThatShouldBeReset.length, bookForm.fieldsToReset.length);
+        Assertions.assertTrue(List.of(bookForm.fieldsToReset)
+                              .containsAll(List.of(fieldsThatShouldBeReset)));
+    }
+
+    @Test
     void shouldNotAllowNegativeSeriesPosition() {
         // given
         bookForm.seriesPosition.setValue(-1);
@@ -610,15 +679,14 @@ public class BookFormTest {
                 Arguments.of(TO_READ, READ),
                 Arguments.of(TO_READ, DID_NOT_FINISH),
                 Arguments.of(READING, DID_NOT_FINISH),
-                Arguments.of(READING, READ)
-                // TODO: these cases are not passing at the moment because of issue #271
-                // Arguments.of(READING, TO_READ),
-                // Arguments.of(READ, TO_READ),
-                // Arguments.of(READ, DID_NOT_FINISH),
-                // Arguments.of(READ, READING),
-                // Arguments.of(DID_NOT_FINISH, TO_READ),
-                // Arguments.of(DID_NOT_FINISH, READING),
-                // Arguments.of(DID_NOT_FINISH, READ)
+                Arguments.of(READING, READ),
+                Arguments.of(READING, TO_READ),
+                Arguments.of(READ, TO_READ),
+                Arguments.of(READ, DID_NOT_FINISH),
+                Arguments.of(READ, READING),
+                Arguments.of(DID_NOT_FINISH, TO_READ),
+                Arguments.of(DID_NOT_FINISH, READING),
+                Arguments.of(DID_NOT_FINISH, READ)
                 );
     }
 

--- a/src/test/java/com/karankumar/bookproject/ui/book/BookFormTest.java
+++ b/src/test/java/com/karankumar/bookproject/ui/book/BookFormTest.java
@@ -647,7 +647,7 @@ public class BookFormTest {
                 Arguments.of(DID_NOT_FINISH, TO_READ),
                 Arguments.of(DID_NOT_FINISH, READING),
                 Arguments.of(DID_NOT_FINISH, READ)
-                );
+        );
     }
 
     /**

--- a/src/test/java/com/karankumar/bookproject/ui/book/BookFormTest.java
+++ b/src/test/java/com/karankumar/bookproject/ui/book/BookFormTest.java
@@ -367,7 +367,7 @@ public class BookFormTest {
 
     @ParameterizedTest
     @MethodSource("shelfNames")
-    void fieldsToResetIsCorrectlyPopulated(PredefinedShelf.ShelfName newShelf) throws NotSupportedException {
+    void fieldsToResetAreCorrectlyPopulated(PredefinedShelf.ShelfName newShelf) throws NotSupportedException {
         // given
         HasValue[] fieldsThatShouldBeReset = bookForm.getFieldsToReset(newShelf);
         populateBookForm(READ, false);


### PR DESCRIPTION
## Summary of change

The fields dateStartedReading, dateFinishedReading, pagesRead, bookReview and rating are reset, when a book is saved to a specific shelf.

X:           field can be present in this state of the book
empty:   the field will be reset when a book is moved to the shelf
| Field               | To Read | Reading | Read | Did Not Finish |
|---------------------|---------|---------|------|----------------|
| pagesRead           |         |         |      | X              |
| dateStartedReading  |         | X       | X    | X              |
| dateFinishedReading |         |         | X    |                |
| bookReview          |         |         | X    |                |
| rating              |         |         | X    |                |

E.g: I have a "read" book with a dateStartedReading and a dateFinishedReading set. I update the book and move it to the "to read" shelf. When I hit "Update book", the values for the dates are set to null in the database.

## Related issue

#271 