### PR TITLE
Add upper limit on numberOfPage and PagesRead

### DIFF
--- a/src/main/java/com/karankumar/bookproject/backend/entity/Book.java
+++ b/src/main/java/com/karankumar/bookproject/backend/entity/Book.java
@@ -29,6 +29,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
+import javax.validation.constraints.Max;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -42,7 +43,9 @@ public class Book extends BaseEntity {
     @NotNull
     @NotEmpty
     private String title;
+    @Max(value = 23000)
     private Integer numberOfPages;
+    @Max(value = 23000)
     private Integer pagesRead;
     private Genre genre;
     private Integer seriesPosition;

--- a/src/test/java/com/karankumar/bookproject/backend/service/BookServiceTest.java
+++ b/src/test/java/com/karankumar/bookproject/backend/service/BookServiceTest.java
@@ -22,10 +22,13 @@ import com.karankumar.bookproject.backend.entity.Author;
 import com.karankumar.bookproject.backend.entity.Book;
 import com.karankumar.bookproject.backend.entity.PredefinedShelf;
 import com.karankumar.bookproject.backend.utils.PredefinedShelfUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.validation.ConstraintViolationException;
 
 @IntegrationTest
 public class BookServiceTest {
@@ -61,6 +64,38 @@ public class BookServiceTest {
     public void whenTryingToSaveBookWithoutAuthorExpectNoSave() {
         bookService.save(new Book("Book without author", null, toRead));
         Assertions.assertEquals(0, authorService.count());
+        Assertions.assertEquals(0, bookService.count());
+    }
+
+    /**
+     * Tests book is not saved with numberOfPages > 23000
+     */
+    @Test
+    public void whenTryingToSaveBookWithMaxNumberPageExceedNoSave() {
+        Book book = new Book("Book without author", new Author("First", "Last"), toRead);
+        book.setNumberOfPages(Integer.MAX_VALUE);
+        try {
+            bookService.save(book);
+        } catch (Exception e)
+        {
+            Assertions.assertTrue(ExceptionUtils.getRootCause(e) instanceof ConstraintViolationException);
+        }
+        Assertions.assertEquals(0, bookService.count());
+    }
+
+    /**
+     * Tests book is not saved with pagesRead > 23000
+     */
+    @Test
+    public void whenTryingToSaveBookWithPagesReadExceedNoSave() {
+        Book book = new Book("Book without author", new Author("First", "Last"), toRead);
+        book.setPagesRead(Integer.MAX_VALUE);
+        try {
+            bookService.save(book);
+        } catch (Exception e)
+        {
+            Assertions.assertTrue(ExceptionUtils.getRootCause(e) instanceof ConstraintViolationException);
+        }
         Assertions.assertEquals(0, bookService.count());
     }
 


### PR DESCRIPTION
## Add upper limit on numberOfPage and PagesRead in book Entity

Add max constraint in book entity for numberOfPage and PagesRead members

## Additional context

[If a screenshot would be useful (e.g. for UI changes), please provide one.]

## Related issue

https://github.com/knjk04/book-project/issues/258

## Pull request checklist

Please ensure you have done the following:

- [x] Read, understood and adhered to our [contributing document](https://github.com/knjk04/book-project/blob/master/CONTRIBUTING.md).
  - [x] Ensure that you were first assigned to a relevant issue before creating this pull request
  - [ ] Ensure code changes pass all tests

- [x] Read, understood and adhered to our [style guide](https://github.com/knjk04/book-project/blob/master/STYLEGUIDE.md). A lot of our code reviews are spent on ensuring compliance with our style guide, so it would save a lot of time if this was adhered to from the outset. 

- [x] Filled in the summary, context (if applicable) and related issue section. Replace the square brackets and its placeholder content with your contents. For an example, see any merged in pull request
  - [ ] Included a screenshot(s) if a UI change was involved (it may look different on a reviewer's device)

- [x] Created a branch that has a descriptive name (what your branch is for a in a few words and includes the issue number at the end, e.g. `test-reading-goal-123`

- [ ] Set this pull request to 'draft' if you are still working on it

- [ ] Resolved any merge conflicts

If in doubt, get in touch with us via our [Gitter room](https://gitter.im/book-project-community/community)
