### PR TITLE
refactor StatisticsView constructor and add related tests

### DIFF
--- a/src/main/java/com/karankumar/bookproject/ui/statistics/StatisticsView.java
+++ b/src/main/java/com/karankumar/bookproject/ui/statistics/StatisticsView.java
@@ -30,85 +30,119 @@ import com.vaadin.flow.component.html.H3;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
+import lombok.Getter;
 import lombok.extern.java.Log;
 
 import java.text.DecimalFormat;
+import java.util.Optional;
+
 
 @Route(value = "statistics", layout = MainView.class)
 @PageTitle("Statistics | Book Project")
 @Log
 public class StatisticsView extends VerticalLayout {
+
     public StatisticsView(PredefinedShelfService predefinedShelfService) {
-        RatingStatistics ratingStatistics = new RatingStatistics(predefinedShelfService);
-        GenreStatistics genreStatistics = new GenreStatistics(predefinedShelfService);
-        PageStatistics pageStatistics = new PageStatistics(predefinedShelfService);
-
-        Double averageRating = ratingStatistics.calculateAverageRatingGiven();
-        if (averageRating != null) {
-            String averageRatingOutOf10 =
-                    String.format("%s/10", new DecimalFormat("#.00").format(averageRating));
-            add(configureStatistic("Average rating given", averageRatingOutOf10));
+        for (StatisticType statistic : StatisticType.values()) {
+            String caption = statistic.getCaption();
+            Optional<String> value = statistic.calculateStatistic(predefinedShelfService);
+            value.ifPresent(val -> add(configureStatistic(caption, val)));
         }
-
-        Book mostLikedBook = ratingStatistics.findMostLikedBook();
-        if (mostLikedBook != null) {
-            String mostLikedBookStatistic =
-                    formatStatistic(mostLikedBook.getTitle(), mostLikedBook.getRating().toString(),
-                            "rating");
-            add(configureStatistic("Most liked book", mostLikedBookStatistic));
-        }
-
-        Book leastLikedBook = ratingStatistics.findLeastLikedBook();
-        if (leastLikedBook != null) {
-            String leastLikedBookRating =
-                    formatStatistic(leastLikedBook.getTitle(), leastLikedBook.getRating().toString(),
-                            "rating");
-            add(configureStatistic("Least liked book", leastLikedBookRating));
-        }
-
-        Genre mostReadGenre = genreStatistics.findMostReadGenre();
-        if (mostReadGenre != null) {
-            add(configureStatistic("Most read genre", mostReadGenre.toString()));
-        }
-
-        Genre mostLikedGenre = genreStatistics.findMostLikedGenre();
-        if (mostLikedGenre != null) {
-            add(configureStatistic("Most liked genre read", mostLikedGenre.toString()));
-        }
-
-        Genre leastLikedGenre = genreStatistics.findLeastLikedGenre();
-        if (leastLikedGenre != null) {
-            add(configureStatistic("Least liked genre read", leastLikedGenre.toString()));
-        }
-
-        Integer averagePageLength = pageStatistics.calculateAveragePageLength();
-        if (averagePageLength != null) {
-            add(configureStatistic("Average page length", String.format("%d pages",
-                    averagePageLength)));
-        }
-
-        Book longestBook = pageStatistics.findBookWithMostPages();
-        if (longestBook != null) {
-            String longestBookStatistic =
-                    formatStatistic(longestBook.getTitle(),
-                            String.valueOf(longestBook.getNumberOfPages()), "pages");
-            add(configureStatistic("Longest book read", longestBookStatistic));
-        }
-
         setSizeFull();
         setAlignItems(Alignment.CENTER);
     }
 
     private Div configureStatistic(String caption, String statistic) {
         Div div = new Div();
-        H3 averageRatingGiven = new H3(caption + ":");
+        H3 averageRatingGiven = new H3(caption);
         VerticalLayout verticalLayout = new VerticalLayout(averageRatingGiven, new Text(statistic));
         verticalLayout.setAlignItems(Alignment.CENTER);
         div.add(verticalLayout);
         return div;
     }
 
-    private String formatStatistic(String bookTitle, String statistic, String unit) {
+    private static String formatStatistic(String bookTitle, String statistic, String unit) {
         return String.format("%s (%s %s)", bookTitle, statistic, unit);
     }
+
+    public enum StatisticType {
+        AVERAGE_RATING("Average rating given:") {
+            @Override
+            public Optional<String> calculateStatistic(PredefinedShelfService predefinedShelfService) {
+                RatingStatistics ratingStatistics = new RatingStatistics(predefinedShelfService);
+                Optional<Double> averageRating = Optional.ofNullable(ratingStatistics.calculateAverageRatingGiven());
+                return  averageRating.map(rating -> String.format("%s/10", new DecimalFormat("#.00").format(rating)));
+            }
+        },
+        MOST_LIKED_BOOK("Most liked book:") {
+            @Override
+            public Optional<String>  calculateStatistic(PredefinedShelfService predefinedShelfService) {
+                RatingStatistics ratingStatistics = new RatingStatistics(predefinedShelfService);
+                Optional<Book> mostLikedBook = Optional.ofNullable(ratingStatistics.findMostLikedBook());
+                return mostLikedBook.map(book ->  formatStatistic(book.getTitle(), book.getRating().toString(),
+                        "rating"));
+            }
+        },
+        LEAST_LIKED_BOOK("Least liked book:") {
+            @Override
+            public Optional<String>  calculateStatistic(PredefinedShelfService predefinedShelfService) {
+                RatingStatistics ratingStatistics = new RatingStatistics(predefinedShelfService);
+                Optional<Book> leastLikedBook = Optional.ofNullable(ratingStatistics.findLeastLikedBook());
+                return leastLikedBook.map(book -> formatStatistic(book.getTitle(), book.getRating().toString(),
+                        "rating"));
+            }
+        },
+
+        MOST_READ_GENRE("Most read genre:") {
+            @Override
+            public Optional<String>  calculateStatistic(PredefinedShelfService predefinedShelfService) {
+                GenreStatistics genreStatistics = new GenreStatistics(predefinedShelfService);
+                Optional<Genre> mostReadGenre = Optional.ofNullable(genreStatistics.findMostReadGenre());
+                return mostReadGenre.map(genre -> genre.toString());
+            }
+        },
+        MOST_LIKED_GENRE("Most liked genre read:") {
+            @Override
+            public Optional<String> calculateStatistic(PredefinedShelfService predefinedShelfService) {
+                GenreStatistics genreStatistics = new GenreStatistics(predefinedShelfService);
+                Optional<Genre> mostLikedGenre = Optional.ofNullable(genreStatistics.findMostLikedGenre());
+                return mostLikedGenre.map(genre -> genre.toString());
+            }
+        },
+        LEAST_LIKED_GENRE("Least liked genre read:") {
+            @Override
+            public Optional<String> calculateStatistic(PredefinedShelfService predefinedShelfService) {
+                GenreStatistics genreStatistics = new GenreStatistics(predefinedShelfService);
+                Optional<Genre> leastLikedGenre = Optional.ofNullable(genreStatistics.findLeastLikedGenre());
+                return leastLikedGenre.map(genre -> genre.toString());
+            }
+        },
+        AVERAGE_PAGE_LENGTH("Average page length:") {
+            @Override
+            public Optional<String> calculateStatistic(PredefinedShelfService predefinedShelfService) {
+                PageStatistics pageStatistics = new PageStatistics(predefinedShelfService);
+                Optional<Integer> averagePageLength = Optional.ofNullable(pageStatistics.calculateAveragePageLength());
+                return averagePageLength.map(pageLength -> String.format("%d pages", pageLength));
+            }
+        },
+        LONGEST_BOOK("Longest book read:") {
+            @Override
+            public Optional<String>  calculateStatistic(PredefinedShelfService predefinedShelfService) {
+                PageStatistics pageStatistics = new PageStatistics(predefinedShelfService);
+                Optional<Book> longestBook = Optional.ofNullable(pageStatistics.findBookWithMostPages());
+                return longestBook.map(book -> formatStatistic(book.getTitle(), String.valueOf(book.getNumberOfPages()),
+                        "pages"));
+            }
+        };
+
+        StatisticType(String caption) {
+            this.caption = caption;
+        }
+
+        @Getter
+        private final String caption;
+
+        public abstract Optional<String> calculateStatistic(PredefinedShelfService predefinedShelfService);
+    }
+
 }

--- a/src/test/java/com/karankumar/bookproject/ui/statistics/StatisticsViewTest.java
+++ b/src/test/java/com/karankumar/bookproject/ui/statistics/StatisticsViewTest.java
@@ -1,0 +1,198 @@
+package com.karankumar.bookproject.ui.statistics;
+
+import com.karankumar.bookproject.annotations.IntegrationTest;
+
+import com.karankumar.bookproject.backend.service.BookService;
+import com.karankumar.bookproject.backend.service.PredefinedShelfService;
+
+import com.karankumar.bookproject.ui.statistics.util.StatisticsViewTestUtils;
+import static com.karankumar.bookproject.ui.statistics.StatisticsView.StatisticType;
+import static com.karankumar.bookproject.ui.statistics.util.StatisticsViewTestUtils.populateDataWithBooks;
+import static com.karankumar.bookproject.ui.statistics.util.StatisticsViewTestUtils.populateDataWithBooksWithoutRatings;
+import static com.karankumar.bookproject.ui.statistics.util.StatisticsViewTestUtils.populateDataWithBooksWithoutGenre;
+import static com.karankumar.bookproject.ui.statistics.util.StatisticsViewTestUtils.populateDataWithBooksWithoutPageCount;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import java.util.Arrays;
+
+@IntegrationTest
+@WebAppConfiguration
+public class StatisticsViewTest {
+
+    @Autowired
+    private PredefinedShelfService predefinedShelfService;
+
+    @Autowired
+    private BookService bookService;
+
+    private StatisticsView statisticsView;
+
+
+    @BeforeEach
+    public void setup() {
+        bookService.deleteAll();
+    }
+
+    @Test
+    void shouldCreateCompleteStatisticsView() {
+        // given
+        populateDataWithBooks(bookService, predefinedShelfService);
+
+        // when
+        statisticsView = new StatisticsView(predefinedShelfService);
+
+        // then
+        allStatisticsAreShown();
+        thereAreNotOtherStatistics();
+    }
+
+    private void allStatisticsAreShown() {
+        Arrays.asList(StatisticType.values())
+                .forEach(statisticType -> valueIsPresent(getStatistic(statisticType)));
+    }
+
+    private void valueIsPresent(Statistic currentStatistic) {
+        Assertions.assertFalse(currentStatistic instanceof StatisticNotFound);
+
+    }
+    
+    private void thereAreNotOtherStatistics() {
+        Assertions.assertEquals(StatisticType.values().length, statisticsView.getComponentCount());
+    }
+
+    @Test
+    void eachStatisticShouldBHaveAValue() {
+        // given
+        populateDataWithBooks(bookService, predefinedShelfService);
+
+        // when
+        statisticsView = new StatisticsView(predefinedShelfService);
+
+        // then
+        eachStatisticHasAValue();
+    }
+
+    private void eachStatisticHasAValue() {
+        Arrays.asList(StatisticType.values())
+              .forEach(statisticType -> valueIsPresent(getStatistic(statisticType)));
+    }
+
+    @Test
+    void withoutPageCountTheViewShouldShowOtherStatistics() {
+        // given
+        populateDataWithBooksWithoutPageCount(bookService, predefinedShelfService);
+
+        // when
+        statisticsView = new StatisticsView(predefinedShelfService);
+
+        // then
+        pageStatisticsAreAbsent();
+        ratingStatisticsArePresent();
+        genreStatisticIsPresent();
+        genreAndRatingStatisticsArePresent();
+    }
+
+    @Test
+    void withoutGenreInformationTheViewShouldShowOtherStatistics() {
+        // given
+        populateDataWithBooksWithoutGenre(bookService, predefinedShelfService);
+
+        // when
+        statisticsView = new StatisticsView(predefinedShelfService);
+
+        // then
+        genreStatisticIsAbsent();
+        genreAndRatingStatisticsAreAbsent();
+        ratingStatisticsArePresent();
+        pageStatisticsArePresent();
+    }
+
+    @Test
+    void withoutRatingInformationTheViewShouldShowOtherStatistics() {
+        // given
+        populateDataWithBooksWithoutRatings(bookService, predefinedShelfService);
+
+        // when
+        statisticsView = new StatisticsView(predefinedShelfService);
+
+        // then
+        ratingStatisticsAreAbsent();
+        genreAndRatingStatisticsAreAbsent();
+        genreStatisticIsPresent();
+        pageStatisticsArePresent();
+    }
+
+    private void pageStatisticsArePresent() {
+        statisticIsPresent(StatisticType.LONGEST_BOOK);
+        statisticIsPresent(StatisticType.AVERAGE_PAGE_LENGTH);
+    }
+
+    private void pageStatisticsAreAbsent() {
+        statisticIsAbsent(StatisticType.LONGEST_BOOK);
+        statisticIsAbsent(StatisticType.AVERAGE_PAGE_LENGTH);
+    }
+
+    private void ratingStatisticsArePresent() {
+        statisticIsPresent(StatisticType.AVERAGE_RATING);
+        statisticIsPresent(StatisticType.MOST_LIKED_BOOK);
+        statisticIsPresent(StatisticType.LEAST_LIKED_BOOK);
+    }
+
+    private void ratingStatisticsAreAbsent() {
+        statisticIsAbsent(StatisticType.AVERAGE_RATING);
+        statisticIsAbsent(StatisticType.MOST_LIKED_BOOK);
+        statisticIsAbsent(StatisticType.LEAST_LIKED_BOOK);
+    }
+
+    private void genreStatisticIsPresent() {
+        statisticIsPresent(StatisticType.MOST_READ_GENRE);
+    }
+
+    private void genreStatisticIsAbsent() {
+        statisticIsAbsent(StatisticType.MOST_READ_GENRE);
+
+    }
+
+    private void genreAndRatingStatisticsArePresent() {
+        statisticIsPresent(StatisticType.MOST_LIKED_GENRE);
+        statisticIsPresent(StatisticType.LEAST_LIKED_GENRE);
+    }
+
+    private void genreAndRatingStatisticsAreAbsent() {
+        statisticIsAbsent(StatisticType.MOST_LIKED_GENRE);
+        statisticIsAbsent(StatisticType.LEAST_LIKED_GENRE);
+    }
+
+    private void statisticIsAbsent(StatisticType statisticType) {
+        Assertions.assertTrue(getStatistic(statisticType) instanceof StatisticNotFound);
+    }
+
+    private void statisticIsPresent(StatisticType statisticType) {
+        Assertions.assertEquals(statisticType.getCaption(), getStatistic(statisticType).getCaption());
+    }
+
+    private Statistic getStatistic(StatisticType statisticType) {
+        return StatisticsViewTestUtils.getStatistic(statisticType, statisticsView);
+    }
+
+    @AllArgsConstructor
+    public static class Statistic {
+        @Getter
+        private final String caption;
+        @Getter
+        private final String value;
+    }
+
+    public static class StatisticNotFound extends Statistic {
+        public StatisticNotFound() {
+            super("statistic", "not found");
+        }
+    }
+}

--- a/src/test/java/com/karankumar/bookproject/ui/statistics/util/StatisticsViewTestUtils.java
+++ b/src/test/java/com/karankumar/bookproject/ui/statistics/util/StatisticsViewTestUtils.java
@@ -1,0 +1,93 @@
+package com.karankumar.bookproject.ui.statistics.util;
+
+import com.karankumar.bookproject.backend.entity.Author;
+import com.karankumar.bookproject.backend.entity.Book;
+import com.karankumar.bookproject.backend.entity.Genre;
+import com.karankumar.bookproject.backend.entity.RatingScale;
+import com.karankumar.bookproject.backend.service.BookService;
+import com.karankumar.bookproject.backend.entity.PredefinedShelf;
+import com.karankumar.bookproject.backend.service.PredefinedShelfService;
+import com.karankumar.bookproject.backend.utils.PredefinedShelfUtils;
+import com.karankumar.bookproject.ui.statistics.StatisticsView;
+import com.karankumar.bookproject.ui.statistics.StatisticsViewTest.Statistic;
+import com.karankumar.bookproject.ui.statistics.StatisticsViewTest.StatisticNotFound;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.dom.Element;
+
+import java.util.function.Predicate;
+
+public class StatisticsViewTestUtils {
+
+    private StatisticsViewTestUtils() {}
+
+    public static Statistic getStatistic(StatisticsView.StatisticType statisticType, StatisticsView statisticsView) {
+        try {
+            Element verticalLayoutInDiv = getVerticalLayoutWithStatistic(statisticType, statisticsView);
+            // statistic caption is in VL -> H3 -> Text
+            String caption = verticalLayoutInDiv.getChild(0)
+                                                .getText();
+            // statistic value is in VL -> Text
+            String value = verticalLayoutInDiv.getText();
+            return new Statistic(caption, value);
+        } catch (Exception e) {
+            return new StatisticNotFound();
+        }
+    }
+
+    private static Element getVerticalLayoutWithStatistic(StatisticsView.StatisticType statisticType, StatisticsView statisticsView) {
+        var divContainingStatistic = statisticsView.getChildren()
+                                                            .filter(textWithinH3EqualsTo(statisticType.getCaption()))
+                                                            .findFirst()
+                                                            .get()
+                                                            .getElement();
+        var verticalLayoutInDiv = divContainingStatistic.getChild(0);
+        return verticalLayoutInDiv;
+    }
+
+    private static Predicate<Component> textWithinH3EqualsTo(String text) {
+        return x -> x.getElement() // DIV ->
+                .getChild(0) // VerticalLayout ->
+                .getChild(0) // H3 ->
+                .getText() // Text
+                .equals(text);
+    }
+
+    public static void populateDataWithBooks(BookService bookService, PredefinedShelfService predefinedShelfService) {
+        Book book = createMobyDickBook(predefinedShelfService);
+        bookService.save(book);
+    }
+    
+    public static void populateDataWithBooksWithoutPageCount(BookService bookService, PredefinedShelfService predefinedShelfService) {
+        Book book = createMobyDickBook(predefinedShelfService);
+        book.setNumberOfPages(null);
+        bookService.save(book);
+    }
+
+    public static void populateDataWithBooksWithoutGenre(BookService bookService, PredefinedShelfService predefinedShelfService) {
+        Book book = createMobyDickBook(predefinedShelfService);
+        book.setGenre(null);
+        bookService.save(book);
+    }
+
+    public static void populateDataWithBooksWithoutRatings(BookService bookService, PredefinedShelfService predefinedShelfService) {
+        Book book = createMobyDickBook(predefinedShelfService);
+        book.setRating(null);
+        bookService.save(book);
+    }
+
+    private static PredefinedShelf getReadShelf(PredefinedShelfService predefinedShelfService) {
+        PredefinedShelfUtils predefinedShelfUtils = new PredefinedShelfUtils(predefinedShelfService);
+        return predefinedShelfUtils.findReadShelf();
+    }
+
+    private static Book createMobyDickBook(PredefinedShelfService predefinedShelfService) {
+        PredefinedShelf readShelf = getReadShelf(predefinedShelfService);
+        Author author = new Author("Herman", "Melville");
+        Book book = new Book("Moby Dick", author, readShelf);
+        book.setGenre(Genre.ADVENTURE);
+        book.setNumberOfPages(2000);
+        book.setPagesRead(1000);
+        book.setRating(RatingScale.EIGHT_POINT_FIVE);
+        return book;
+    }
+}


### PR DESCRIPTION
## Summary of change

This PR adds tests for the view and uses the strategy pattern with enum (a statistic for each enum values) to refactor the StatisticsView constructor: it allows to add new statistic editing the enum without touching the constructor itself.

## Related issue

#215 

## Pull request checklist

Please ensure you have done the following:

- [x] Read, understood and adhered to our [contributing document](https://github.com/knjk04/book-project/blob/master/CONTRIBUTING.md).
  - [x] Ensure that you were first assigned to a relevant issue before creating this pull request
  - [x] Ensure code changes pass all tests

- [x] Read, understood and adhered to our [style guide](https://github.com/knjk04/book-project/blob/master/STYLEGUIDE.md). A lot of our code reviews are spent on ensuring compliance with our style guide, so it would save a lot of time if this was adhered to from the outset. 

- [x] Filled in the summary, context (if applicable) and related issue section. Replace the square brackets and its placeholder content with your contents. For an example, see any merged in pull request
  - [x] Included a screenshot(s) if a UI change was involved (it may look different on a reviewer's device)

- [x] Created a branch that has a descriptive name (what your branch is for a in a few words and includes the issue number at the end, e.g. `test-reading-goal-123`

- [x] Set this pull request to 'draft' if you are still working on it

- [x] Resolved any merge conflicts

If in doubt, get in touch with us via our [Gitter room](https://gitter.im/book-project-community/community)
