### PR TITLE
Link the mysql service to phpmyadmin using db as name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     command: --init-file /data/application/init.sql
   phpmyadmin:
     image: phpmyadmin/phpmyadmin:latest
+    links:
+      - mysql:db
     ports:
       - "8081:80"
   bookapp:


### PR DESCRIPTION
## Summary of change
The mysql service is now linked to the phpmyadmin service using db as name, so phpmyadmin can find the database.

## Related issue
#307 
